### PR TITLE
Use standard library path for pfw plugin location

### DIFF
--- a/Android.mk
+++ b/Android.mk
@@ -46,7 +46,6 @@ LOCAL_STATIC_LIBRARIES := \
     libparameter_includes \
     libxmlserializer_includes
 
-LOCAL_MODULE_PATH := $(TARGET_OUT_SHARED_LIBRARIES)/parameter-framework-plugins/Fs
 LOCAL_MODULE_TAGS := optional
 LOCAL_MODULE := libfs-subsystem
 


### PR DESCRIPTION
This pull request is about the plugin's installation directory on an Android target.

With this patch, the plugin is installed in the standard shared library directory, instead of in a custom location
