### PR TITLE
Android.mk: declare intel as module owner

### DIFF
--- a/Android.mk
+++ b/Android.mk
@@ -49,6 +49,7 @@ LOCAL_STATIC_LIBRARIES := \
 LOCAL_MODULE_PATH := $(TARGET_OUT_SHARED_LIBRARIES)/parameter-framework-plugins/Fs
 LOCAL_MODULE_TAGS := optional
 LOCAL_MODULE := libfs-subsystem
+LOCAL_MODULE_OWNER := intel
 
 include external/stlport/libstlport.mk
 include $(BUILD_SHARED_LIBRARY)


### PR DESCRIPTION
This is mandatory for our internal usages.
