### PR TITLE
Link to shared library xmlSerializer

### DIFF
--- a/Android.mk
+++ b/Android.mk
@@ -41,10 +41,7 @@ LOCAL_CFLAGS := \
     -Wextra \
     -Wno-unused-parameter    # Needed to workaround STL bug
 
-LOCAL_SHARED_LIBRARIES := libparameter
-LOCAL_STATIC_LIBRARIES := \
-    libparameter_includes \
-    libxmlserializer_includes
+LOCAL_SHARED_LIBRARIES := libparameter libxmlserializer
 
 LOCAL_MODULE_TAGS := optional
 LOCAL_MODULE := libfs-subsystem


### PR DESCRIPTION
The PFw as recently removed (this trick was not working on osx) it's *_include libraries that were used to include headers without linking against the libraries in the android build system.
There is to way to include the headers:
 - copy the headers (but that would be in contradiction with how the main pfw headers are included)
 - link against the library (chosen solution)
To avoid linking against a static libxmlserializer - ie add it and it's dependency to all plugins - the xmlserializer library is now dynamic.

Link against the dynamic library xmlserializer and no longer use *_include.