### PR TITLE
Update to Parameter Framework 3.0 API

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright (c) 2014, Intel Corporation
+# Copyright (c) 2014-2015, Intel Corporation
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without modification,
@@ -31,31 +31,26 @@ cmake_minimum_required(VERSION 2.8)
 
 project(parameter-framework-plugins-filesystem)
 
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Werror -Wall -Wextra")
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11 -Werror -Wall -Wextra")
 
 #
 # Find PFW libraries and include directories
 #
-find_path(PFW_CORE_ROOT_DIR NAMES include/parameter/plugin/Subsystem.h)
+find_path(PFW_INCLUDE_ROOT NAMES parameter/plugin/Plugin.h)
 
-find_library(PFW_CORE_LIBRARY NAMES parameter
-    HINTS ${PFW_CORE_ROOT_DIR}/lib)
+find_library(PFW_CORE_LIBRARY NAMES parameter)
 
-find_path(PFW_CORE_INCLUDE_DIR NAMES Subsystem.h
-    HINTS ${PFW_CORE_ROOT_DIR}/include/parameter/plugin)
-find_path(PFW_XMLSERIALIZER_INCLUDE_DIR NAMES XmlSink.h
-    HINTS ${PFW_CORE_ROOT_DIR}/include/xmlserializer)
-
-set(PFW_INCLUDE_DIRS ${PFW_CORE_INCLUDE_DIR} ${PFW_XMLSERIALIZER_INCLUDE_DIR})
-set(PFW_LIBRARIES ${PFW_CORE_LIBRARY})
-
+set(PFW_INCLUDE_DIRS
+    ${PFW_INCLUDE_ROOT}/parameter/plugin
+    ${PFW_INCLUDE_ROOT}/xmlserializer
+    ${PFW_INCLUDE_ROOT}/utility)
 
 add_library(fs-subsystem SHARED
 FSSubsystemBuilder.cpp
 FSSubsystem.cpp
 FSSubsystemObject.cpp)
 
-target_link_libraries(fs-subsystem ${PFW_LIBRARIES})
+target_link_libraries(fs-subsystem ${PFW_CORE_LIBRARY})
 
 include_directories(${PFW_INCLUDE_DIRS})
 

--- a/FSSubsystem.cpp
+++ b/FSSubsystem.cpp
@@ -1,5 +1,5 @@
 /*
-* Copyright (c) 2011-2014, Intel Corporation
+* Copyright (c) 2011-2015, Intel Corporation
 * All rights reserved.
 *
 * Redistribution and use in source and binary forms, with or without modification,
@@ -36,7 +36,8 @@
 #define base CSubsystem
 
 // Implementation
-CFSSubsystem::CFSSubsystem(const std::string& strName) : base(strName)
+CFSSubsystem::CFSSubsystem(const std::string& strName, core::log::Logger& logger) :
+    base(strName, logger)
 {
     // Provide mapping keys to upper layer
     addContextMappingKey("Directory");

--- a/FSSubsystem.h
+++ b/FSSubsystem.h
@@ -1,5 +1,5 @@
 /*
-* Copyright (c) 2011-2014, Intel Corporation
+* Copyright (c) 2011-2015, Intel Corporation
 * All rights reserved.
 *
 * Redistribution and use in source and binary forms, with or without modification,
@@ -36,7 +36,7 @@
 class CFSSubsystem : public CSubsystem
 {
 public:
-    CFSSubsystem(const std::string& strName);
+    CFSSubsystem(const std::string& strName, core::log::Logger& logger);
 
 };
 

--- a/FSSubsystemBuilder.cpp
+++ b/FSSubsystemBuilder.cpp
@@ -1,5 +1,5 @@
 /*
-* Copyright (c) 2011-2014, Intel Corporation
+* Copyright (c) 2011-2015, Intel Corporation
 * All rights reserved.
 *
 * Redistribution and use in source and binary forms, with or without modification,
@@ -28,15 +28,17 @@
 * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 */
 
-#include "SubsystemLibrary.h"
-#include "NamedElementBuilderTemplate.h"
+#include <Plugin.h>
+#include <LoggingElementBuilderTemplate.h>
 #include "FSSubsystem.h"
 
 
 extern "C"
 {
-void getFSSubsystemBuilder(CSubsystemLibrary* pSubsystemLibrary)
+void PARAMETER_FRAMEWORK_PLUGIN_ENTRYPOINT_V1(CSubsystemLibrary* subsystemLibrary,
+                                              core::log::Logger& logger)
 {
-    pSubsystemLibrary->addElementBuilder("FS", new TNamedElementBuilderTemplate<CFSSubsystem>());
+    subsystemLibrary->addElementBuilder("FS",
+                                        new TLoggingElementBuilderTemplate<CFSSubsystem>(logger));
 }
 }

--- a/FSSubsystemObject.cpp
+++ b/FSSubsystemObject.cpp
@@ -1,5 +1,5 @@
 /*
-* Copyright (c) 2011-2014, Intel Corporation
+* Copyright (c) 2011-2015, Intel Corporation
 * All rights reserved.
 *
 * Redistribution and use in source and binary forms, with or without modification,
@@ -53,8 +53,10 @@ const uint32_t STR_FORMAT_LENGTH = 1024;
 
 CFSSubsystemObject::CFSSubsystemObject(const string& mappingValue,
                                        CInstanceConfigurableElement* instanceConfigurableElement,
-                                       const CMappingContext& context)
+                                       const CMappingContext& context,
+                                       core::log::Logger& logger)
     : base(instanceConfigurableElement,
+           logger,
            mappingValue,
            EFSAmend1,
            (EFSAmendEnd - EFSAmend1 + 1),

--- a/FSSubsystemObject.h
+++ b/FSSubsystemObject.h
@@ -1,5 +1,5 @@
 /*
-* Copyright (c) 2011-2014, Intel Corporation
+* Copyright (c) 2011-2015, Intel Corporation
 * All rights reserved.
 *
 * Redistribution and use in source and binary forms, with or without modification,
@@ -41,7 +41,8 @@ class CFSSubsystemObject : public CFormattedSubsystemObject
 public:
     CFSSubsystemObject(const std::string& mappingValue,
                        CInstanceConfigurableElement* instanceConfigurableElement,
-                       const CMappingContext& context);
+                       const CMappingContext& context,
+                       core::log::Logger& logger);
 
 protected:
     // from CSubsystemObject


### PR DESCRIPTION
PF 3.0 provides a new logging API and a new entry-point API.

It also makes it necessary to compile using C++11.

This patch update the filesystem plugin to let it compile against the new PF.