### PR TITLE
Add binary and block serialization features

### DIFF
--- a/FSMappingKeys.h
+++ b/FSMappingKeys.h
@@ -33,6 +33,7 @@
 // Mapping item types
 enum FSItemType {
     EFSDirectory,
+    EFSBinary,
     EFSAmend1,
     EFSAmend2,
     EFSAmend3,

--- a/FSSubsystem.cpp
+++ b/FSSubsystem.cpp
@@ -41,6 +41,7 @@ CFSSubsystem::CFSSubsystem(const std::string& strName, core::log::Logger& logger
 {
     // Provide mapping keys to upper layer
     addContextMappingKey("Directory");
+    addContextMappingKey("Binary");
     addContextMappingKey("Amend1");
     addContextMappingKey("Amend2");
     addContextMappingKey("Amend3");

--- a/FSSubsystemObject.h
+++ b/FSSubsystemObject.h
@@ -135,4 +135,6 @@ protected:
     bool _wrongElementTypeErrorOccured;
     // Format for reading
     bool _stringFormat;
+    // Is the object to be written in binary format?
+    bool _isBinary;
 };

--- a/README.md
+++ b/README.md
@@ -4,6 +4,20 @@ This is a file system plugin for the
 [parameter-framework](https://github.com/01org/parameter-framework)
 handling file system operations such as `read()` and `write()`.
 
+By default, the plugin reads/writes individual parameters (numerical and
+strings) as strings (one parameter per file or one array per file). This can
+be overriden using the `Binary` mapping key; when added to a parameter or a
+block (ParameterBlock or Component), the plugin reads/writes them in binary
+(in-memory representation). e.g.:
+
+```xml
+<ParameterBlock Name="foo" Mapping="Binary,File:bar">
+    <IntegerParameter .../>
+    <ParameterBlock ...>
+    </ParameterBlock>
+    ...
+</ParameterBlock>
+```
 
 ## Compiling
 


### PR DESCRIPTION
Using the new `Binary` context mapping, parameters can now be written
in binary format (in-memory serialization).

The `File` instanciation mapping can now be asigned to blocks of
parameters (but only in combination with the `Binary` context mapping,
i.e. blocks can only be serialized in binary format).

Signed-off-by: David Wagner <david.wagner@intel.com>